### PR TITLE
Move to AES256, .NET 4.5, and change obsoleted keypass functions

### DIFF
--- a/CertKeyProviderPlugin/CertKeyProvider.cs
+++ b/CertKeyProviderPlugin/CertKeyProvider.cs
@@ -161,9 +161,9 @@ namespace CertKeyProviderPlugin
                 // fall back on opening a local file
                 // FUTURE ENHANCEMENT: allow user to enter a URL and name/pwd as well
 
-                OpenFileDialog ofd = UIUtil.CreateOpenFileDialog(Res.str(Res.STR_OPEN_KEY_FILE),
+                OpenFileDialog ofd = (OpenFileDialog)UIUtil.CreateOpenFileDialog(Res.str(Res.STR_OPEN_KEY_FILE),
                     UIUtil.CreateFileTypeFilter(CertProtKeyFileExtension, Res.str(Res.STR_CERT_PROT_KEY_FILE), true),
-                    1, CertProtKeyFileExtension, false /* multi-select */, true);
+                    1, CertProtKeyFileExtension, false /* multi-select */, string.Empty).FileDialog;
 
                 if (ofd.ShowDialog() != DialogResult.OK)
                 {
@@ -215,10 +215,10 @@ namespace CertKeyProviderPlugin
             MessageBox.Show(Res.str(Res.STR_ENC_KEY_INTRO), Res.str(Res.STR_APP_TITLE), 
                 MessageBoxButtons.OK, MessageBoxIcon.Information);
 
-            SaveFileDialog sfd = UIUtil.CreateSaveFileDialog(Res.str(Res.STR_CREATE_KEY_FILE),
+            SaveFileDialog sfd = (SaveFileDialog)UIUtil.CreateSaveFileDialog(Res.str(Res.STR_CREATE_KEY_FILE),
 			    UrlUtil.StripExtension(UrlUtil.GetFileName(strPath)) + "." +
 			    CertProtKeyFileExtension, UIUtil.CreateFileTypeFilter(CertProtKeyFileExtension,
-                Res.str(Res.STR_CERT_PROT_KEY_FILE), true), 1, CertProtKeyFileExtension, true);
+                Res.str(Res.STR_CERT_PROT_KEY_FILE), true), 1, CertProtKeyFileExtension, string.Empty).FileDialog;
 
 		    if(sfd.ShowDialog() != DialogResult.OK)
 		    {

--- a/CertKeyProviderPlugin/CertKeyProviderPlugin.csproj
+++ b/CertKeyProviderPlugin/CertKeyProviderPlugin.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CertKeyProviderPlugin</RootNamespace>
     <AssemblyName>CertKeyProviderPlugin</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>CertProviderPluginKey.snk</AssemblyOriginatorKeyFile>
@@ -34,6 +34,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -43,6 +44,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -51,11 +53,12 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="KeePass, Version=2.0.8.24423, Culture=neutral, PublicKeyToken=7952fc8ece49a093, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\KeePass-2.35\KeePass.exe</HintPath>
+      <HintPath>..\..\..\keepass\KeePass.exe</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">

--- a/CertKeyProviderPlugin/CertKeyProviderResources.Designer.cs
+++ b/CertKeyProviderPlugin/CertKeyProviderResources.Designer.cs
@@ -19,7 +19,7 @@ namespace CertKeyProviderPlugin {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class CertKeyProviderResources {

--- a/CertKeyProviderPlugin/CryptoTools.cs
+++ b/CertKeyProviderPlugin/CryptoTools.cs
@@ -47,9 +47,9 @@ namespace CertKeyProviderPlugin
             //  Instantiate an EnvelopedCms object with the ContentInfo
             //  above.
             //  Has default SubjectIdentifierType IssuerAndSerialNumber.
-            //  Has default ContentEncryptionAlgorithm property value
-            //  RSA_DES_EDE3_CBC.
-            EnvelopedCms envelopedCms = new EnvelopedCms(contentInfo);
+            //  Force usage of AES256 instead of 3DES
+            Oid aes256 = Oid.FromFriendlyName("aes256", OidGroup.EncryptionAlgorithm);
+            EnvelopedCms envelopedCms = new EnvelopedCms(contentInfo, new AlgorithmIdentifier(aes256));
 
             //  Formulate a CmsRecipient object collection that
             //  represent information about the recipients 


### PR DESCRIPTION
* Forces AES256 (default on .NET 4.8, but..)
* Updates to .NET 4.5 (seems reasonable at this point and gives the OID friendlyname stuff)
* Updated two obsoleted functions in the latest keypass binaries